### PR TITLE
ISAP-420 Add Trivy scans in INFO mode

### DIFF
--- a/.github/workflows/trivy-scheduled.yml
+++ b/.github/workflows/trivy-scheduled.yml
@@ -1,0 +1,69 @@
+name: Trivy scheduled scans
+
+on:
+  schedule:
+    # 00:00 every 14 days 
+    - cron: 0 0 */14 * *
+
+jobs:
+  trivy-repo-scan:
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    name: Trivy scheduled repo scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          submodules: recursive
+      - name: Checkout LFS objects
+        run: git lfs checkout
+
+      - name: Run Trivy vulnerability scanner in repo mode (sarif)
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+  trivy-image-scan:
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    name: Trivy scheduled image scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          submodules: recursive
+      - name: Checkout LFS objects
+        run: git lfs checkout
+
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t ${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner in image mode (sarif output)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ github.sha }}'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+ 
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,92 @@
+name: Trivy scan
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    types: [opened, reopened]
+  schedule:
+    # 00:00 every 14 days 
+    - cron: 0 0 */14 * *
+    
+permissions:
+  contents: read
+
+jobs:
+  trivy-repo-scan:
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    name: Trivy repo scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:     
+          lfs: true
+          submodules: recursive
+
+      - name: Checkout LFS objects
+        run: git lfs checkout
+
+      - name: Run Trivy vulnerability scanner in repo mode (table)
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'table'
+
+      - name: Run Trivy vulnerability scanner in repo mode (sarif)
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+  trivy-image-scan:
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    name: Trivy image scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          submodules: recursive
+
+      - name: Checkout LFS objects
+        run: git lfs checkout
+
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t ${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner in image mode (table output)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ github.sha }}'
+          ignore-unfixed: true
+          format: 'table'
+
+      - name: Run Trivy vulnerability scanner in image mode (sarif output)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ github.sha }}'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+ 
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Implement GitHub actions in INFO mode : 

1. Trivy scan for a repository and Docker image, triggered by open PR and push to master.
2. Trivy scan for a repository and Docker image, triggered by a cron job every 2 weeks.

**That changes do not impact any production services and are only related to the CI process.**